### PR TITLE
Fix: egrep usage, and nitpick with cp command

### DIFF
--- a/_posts/2020-04-15-Using libpst to convert PST to MBOX, and understanding Thunderbird's folder structure.md
+++ b/_posts/2020-04-15-Using libpst to convert PST to MBOX, and understanding Thunderbird's folder structure.md
@@ -111,7 +111,7 @@ Finally, we need to add the files that signify no mailbox, but a subdirectory.
 
 <br>
 
-`find out -type d | egrep *.sbd | sed 's/.\{4\}$//' | xargs -d '\n' touch`
+`find out -type d | egrep '*.sbd' | sed 's/.\{4\}$//' | xargs -d '\n' touch`
 
 
 <br>
@@ -125,7 +125,7 @@ I prefer to add my folders to my Local Computer before dragging it into my IMAP 
 
 <br>
 
-`cp -r out/* ~/.thunderbird/<id>/Mail/Local\ Folders/`
+`cp -a out/* ~/.thunderbird/<id>/Mail/Local\ Folders/`
 
 <br>
 


### PR DESCRIPTION
When copying a directory "as is", usually 'cp -a' is a better fit.